### PR TITLE
sql: clean up arrow depedencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     ./python/run-tests.py and ./python/setup.py too.
     -->
     <!--arrow.version>0.12.0</arrow.version-->
-    <arrow.version>1.0.0-SNAPSHOT</arrow.version>
+    <arrow.version>0.15.0-SNAPSHOT</arrow.version>
 
     <test.java.home>${java.home}</test.java.home>
     <test.exclude.tags></test.exclude.tags>

--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -117,6 +117,7 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
+      <version>${arrow.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/arrow/ArrowConverters.scala
@@ -26,7 +26,7 @@ import org.apache.arrow.flatbuf.MessageHeader
 import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.ipc.{ArrowStreamWriter, ReadChannel, WriteChannel}
-import org.apache.arrow.vector.ipc.message.{ArrowRecordBatch, IpcOption, MessageSerializer}
+import org.apache.arrow.vector.ipc.message.{ArrowRecordBatch, MessageSerializer}
 
 import org.apache.spark.TaskContext
 import org.apache.spark.api.java.JavaRDD
@@ -64,7 +64,7 @@ private[sql] class ArrowBatchStreamWriter(
    * End the Arrow stream, does not close output stream.
    */
   def end(): Unit = {
-    ArrowStreamWriter.writeEndOfStream(writeChannel, new IpcOption())
+    ArrowStreamWriter.writeEndOfStream(writeChannel)
   }
 }
 


### PR DESCRIPTION
- update to use 0.15.0-SNAPSHOT
- remove IpcOption in Arrow Message

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>